### PR TITLE
FromMidi: treat NoteOn with zero velocity as NoteOff.

### DIFF
--- a/Euterpea/IO/MIDI/FromMidi.lhs
+++ b/Euterpea/IO/MIDI/FromMidi.lhs
@@ -98,7 +98,9 @@ list represents a track in the original Midi.
 >   simplifyTrack :: Int -> [(Ticks, Message)] -> [SimpleMsg]
 >   simplifyTrack icur [] = []
 >   simplifyTrack icur ((t,m):ts) = 
->     case m of (NoteOn c p v) -> 
+>     case m of (NoteOn c p 0) ->
+>                   SE (fromIntegral t, p, 0, icur, Off) : simplifyTrack icur ts
+>               (NoteOn c p v) -> 
 >                   SE (fromIntegral t, p, v, icur, On) : simplifyTrack icur ts
 >               (NoteOff c p v) -> 
 >                   SE (fromIntegral t, p, v, icur, Off) : simplifyTrack icur ts


### PR DESCRIPTION
This whole thing appears to be a "hack" from MIDI standard creators.
For "running status" feature to be saving more bandwidth, they allowed
to represent NoteOff events by NoteOn, and use velocity = 0 to indicate
that this is really NoteOff, not NoteOn.

I could not find exact link to specification of this feature, but for example here is some explanation: https://www.kvraudio.com/forum/viewtopic.php?p=4167096 .

There is off course a question about whether this feature should be recognized by HCodecs or by Euterpea. However, as far as I understand, from the point of view of MIDI standard, such events are actually NoteOns, specification only says they are to be treated as NoteOffs. So HCodecs decodes them correctly, and it is Euterpea's responsibility to treat them somehow.

I have a number of MIDI files in which this feature is used a lot. Without this patch, they are parsed into sequence of NoteOn's without NoteOff, so when played by Euterpea, all notes sound forever. This sounds weird. I tested them with this patch, now they sound much, much better :)