### PR TITLE
PortMidi version change (0.2.0.0)

### DIFF
--- a/Euterpea.cabal
+++ b/Euterpea.cabal
@@ -62,7 +62,7 @@ Library
         array>=0.5.0.0 && <=0.6, 
         deepseq>=1.3.0.2 && <=1.5, 
         random>=1.0.1.1 && <=1.2,
-        PortMidi==0.1.6.1, 
+        PortMidi==0.2.0.0,
         HCodecs == 0.5.1, 
         stm >= 2.4 && <2.5, 
         containers>=0.5.5.1 && <0.6, 


### PR DESCRIPTION
Make `Euterpea` compatible with the latest version of PortMidi from hackage, which is `0.2.0.0`.