### PR TITLE
Correct Open Triangle percussion MIDI key in comment

### DIFF
--- a/Euterpea/IO/MIDI/MEvent.lhs
+++ b/Euterpea/IO/MIDI/MEvent.lhs
@@ -66,7 +66,7 @@
 > musicToMEvents c (Modify (Instrument i) m) = musicToMEvents c{mcInst=i} m
 > musicToMEvents c (Modify (Phrase pas) m) = phraseToMEvents c pas m
 > musicToMEvents c (Modify (KeySig x y) m) = musicToMEvents c m -- KeySig causes no change
-> musicToMEvents c (Modify (Custom x) m) = musicToMEvents c m -- Custom cuases no change
+> musicToMEvents c (Modify (Custom x) m) = musicToMEvents c m -- Custom causes no change
 > musicToMEvents c m@(Modify x m') = musicToMEvents c $ applyControls m -- Transpose and Tempo addressed by applyControls
 
 > noteToMEvent :: MContext -> Dur -> (Pitch, [NoteAttribute]) -> MEvent

--- a/Euterpea/Music.lhs
+++ b/Euterpea/Music.lhs
@@ -444,7 +444,7 @@ To remove all zero duration values, use removeZeros.
 >      |  Maracas        | ShortWhistle  | LongWhistle    | ShortGuiro
 >      |  LongGuiro      | Claves        | HiWoodBlock    | LowWoodBlock
 >      |  MuteCuica      | OpenCuica     | MuteTriangle
->      |  OpenTriangle      --  MIDI Key 82
+>      |  OpenTriangle      --  MIDI Key 81
 >    deriving (Show,Eq,Ord,Enum)
 
 > perc :: PercussionSound -> Dur -> Music Pitch


### PR DESCRIPTION
I corrected the comment for the `Open Triangle` percussion sound MIDI key from 82 to 81.

It occurred to me that the number of percussion sounds doesn't match the MIDI number in the comment. I could back this up by multiple sources that I found on the net. Here is one: https://www.midi.org/specifications-old/item/gm-level-1-sound-set

Functionality is unaffected.