### PR TITLE
Update dependencies bytestring and HCodecs

### DIFF
--- a/Euterpea.cabal
+++ b/Euterpea.cabal
@@ -63,9 +63,9 @@ Library
         deepseq>=1.3.0.2 && <=1.5,
         random>=1.0.1.1 && <=1.2,
         PortMidi==0.2.0.0,
-        HCodecs == 0.5.1,
+        HCodecs >= 0.5.1 && < 0.6,
         stm >= 2.4 && <2.6,
         containers>=0.5.5.1 && <0.7,
-        bytestring>=0.10.4.0 && <= 0.10.9,
+        bytestring>=0.10.4.0 && < 0.11,
         heap >= 1.0 && < 2.0,
         ghc-prim


### PR DESCRIPTION
Both packages had new releases. This commit modifies Euterpea.cabal so
that it accepts those versions and Euterpea can be compiled with the
most recent versions of bytestring and HCodecs.

Tested with bytestring 0.10.10.0 and HCodecs 0.5.2, compiles without any problems.