### PR TITLE
Bring everything up to date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 Euterpea/.DS_Store
 .DS_Store
+dist
+dist-newstyle

--- a/Euterpea.cabal
+++ b/Euterpea.cabal
@@ -63,9 +63,9 @@ Library
         deepseq>=1.3.0.2 && <=1.5,
         random>=1.0.1.1 && <=1.2,
         PortMidi==0.2.0.0,
-        HCodecs == 0.5.1,
+        HCodecs >= 0.5.1 && < 0.6,
         stm >= 2.4 && <2.6,
         containers>=0.5.5.1 && <0.7,
-        bytestring>=0.10.4.0 && <= 0.10.9,
+        bytestring>=0.10.4.0 && < 0.11,
         heap >= 1.0 && < 2.0,
         ghc-prim

--- a/Euterpea.cabal
+++ b/Euterpea.cabal
@@ -6,7 +6,7 @@ license-file:	License
 copyright:      Copyright (c) 2008-2019 Euterpea authors
 category:       Sound, Music
 stability:      experimental
-build-type:     Custom
+build-type:     Simple
 author:         Paul Hudak <paul.hudak@yale.edu>,
                 Eric Cheng <eric.cheng@aya.yale.edu>,
                 Hai (Paul) Liu <hai.liu@aya.yale.edu>,

--- a/Euterpea.cabal
+++ b/Euterpea.cabal
@@ -61,11 +61,11 @@ Library
         arrows >= 0.4 && < 0.5,
         array>=0.5.0.0 && <=0.6,
         deepseq>=1.3.0.2 && <=1.5,
-        random>=1.0.1.1 && <=1.2,
+        random>=1.0.1.1 && <=1.3,
         PortMidi==0.2.0.0,
         HCodecs >= 0.5.1 && < 0.6,
         stm >= 2.4 && <2.6,
         containers>=0.5.5.1 && <0.7,
-        bytestring>=0.10.4.0 && < 0.11,
+        bytestring>=0.10.4.0 && < 0.12,
         heap >= 1.0 && < 2.0,
         ghc-prim


### PR DESCRIPTION
This builds with GHC 9.2.3 and Cabal 3.6.2.0.

It incorporates all other currently-open PRs (#38, #47).

Initially inspired by [this Reddit post](https://www.reddit.com/r/haskell/comments/ve8w9k/problems_installing_packages_specifically/), although I've been meaning to pick my own copy of HSoM back up for a while anyway, and I'd much rather make these small fixes than faff about installing an older toolchain.